### PR TITLE
Chunk 6: I/O backend trait + mock implementation

### DIFF
--- a/crates/hiko-vm/src/io_backend.rs
+++ b/crates/hiko-vm/src/io_backend.rs
@@ -4,8 +4,7 @@
 //! request with the backend, and resumes the process when the backend
 //! reports completion. No worker thread is blocked during I/O.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use crate::sendable::SendableValue;
@@ -49,14 +48,12 @@ pub trait IoBackend: Send + Sync {
 /// Mock I/O backend for deterministic testing.
 /// Completes requests immediately or after a configurable delay.
 pub struct MockIoBackend {
-    pending: Mutex<Vec<(IoToken, IoRequest)>>,
     completed: Mutex<Vec<(IoToken, IoResult)>>,
 }
 
 impl MockIoBackend {
     pub fn new() -> Self {
         Self {
-            pending: Mutex::new(Vec::new()),
             completed: Mutex::new(Vec::new()),
         }
     }
@@ -67,7 +64,7 @@ impl IoBackend for MockIoBackend {
         // Mock: complete immediately
         let result = match request {
             IoRequest::Sleep(_) => IoResult::Ok(SendableValue::Unit),
-            IoRequest::Custom { operation, payload } => {
+            IoRequest::Custom { payload, .. } => {
                 // Echo the payload back
                 IoResult::Ok(payload)
             }

--- a/crates/hiko-vm/src/io_backend.rs
+++ b/crates/hiko-vm/src/io_backend.rs
@@ -1,0 +1,122 @@
+//! Abstract I/O backend trait for async operations.
+//!
+//! The runtime suspends a process when it requests I/O, registers the
+//! request with the backend, and resumes the process when the backend
+//! reports completion. No worker thread is blocked during I/O.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::sendable::SendableValue;
+
+/// Opaque token identifying an I/O operation.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct IoToken(pub u64);
+
+/// The kind of I/O operation requested.
+#[derive(Debug, Clone)]
+pub enum IoRequest {
+    /// Delay for a duration (async sleep).
+    Sleep(Duration),
+    /// Custom operation with a name and payload.
+    Custom {
+        operation: String,
+        payload: SendableValue,
+    },
+}
+
+/// Result of a completed I/O operation.
+#[derive(Debug, Clone)]
+pub enum IoResult {
+    /// Operation completed successfully with a value.
+    Ok(SendableValue),
+    /// Operation failed with an error message.
+    Err(String),
+}
+
+/// Abstract I/O backend. Implementations handle the actual I/O
+/// (epoll, io_uring, mock, etc.) without the runtime knowing details.
+pub trait IoBackend: Send + Sync {
+    /// Register an I/O request. The backend will eventually produce a result.
+    fn register(&self, token: IoToken, request: IoRequest);
+
+    /// Poll for completed I/O operations. Returns immediately.
+    /// Non-blocking — returns empty vec if nothing is ready.
+    fn poll(&self) -> Vec<(IoToken, IoResult)>;
+}
+
+/// Mock I/O backend for deterministic testing.
+/// Completes requests immediately or after a configurable delay.
+pub struct MockIoBackend {
+    pending: Mutex<Vec<(IoToken, IoRequest)>>,
+    completed: Mutex<Vec<(IoToken, IoResult)>>,
+}
+
+impl MockIoBackend {
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(Vec::new()),
+            completed: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl IoBackend for MockIoBackend {
+    fn register(&self, token: IoToken, request: IoRequest) {
+        // Mock: complete immediately
+        let result = match request {
+            IoRequest::Sleep(_) => IoResult::Ok(SendableValue::Unit),
+            IoRequest::Custom { operation, payload } => {
+                // Echo the payload back
+                IoResult::Ok(payload)
+            }
+        };
+        self.completed.lock().unwrap().push((token, result));
+    }
+
+    fn poll(&self) -> Vec<(IoToken, IoResult)> {
+        let mut completed = self.completed.lock().unwrap();
+        std::mem::take(&mut *completed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mock_sleep_completes_immediately() {
+        let backend = MockIoBackend::new();
+        backend.register(IoToken(1), IoRequest::Sleep(Duration::from_millis(100)));
+        let results = backend.poll();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, IoToken(1));
+        assert!(matches!(results[0].1, IoResult::Ok(SendableValue::Unit)));
+    }
+
+    #[test]
+    fn test_mock_custom_echoes_payload() {
+        let backend = MockIoBackend::new();
+        backend.register(
+            IoToken(2),
+            IoRequest::Custom {
+                operation: "test".into(),
+                payload: SendableValue::Int(42),
+            },
+        );
+        let results = backend.poll();
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0].1, IoResult::Ok(SendableValue::Int(42))));
+    }
+
+    #[test]
+    fn test_mock_poll_drains() {
+        let backend = MockIoBackend::new();
+        backend.register(IoToken(1), IoRequest::Sleep(Duration::from_millis(0)));
+        let r1 = backend.poll();
+        assert_eq!(r1.len(), 1);
+        let r2 = backend.poll();
+        assert_eq!(r2.len(), 0);
+    }
+}

--- a/crates/hiko-vm/src/lib.rs
+++ b/crates/hiko-vm/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod builder;
 pub mod builtins;
 pub mod heap;
+pub mod io_backend;
 pub mod policy;
 pub mod process;
 pub mod runtime;

--- a/crates/hiko-vm/src/process.rs
+++ b/crates/hiko-vm/src/process.rs
@@ -16,6 +16,8 @@ pub enum BlockReason {
     Receive,
     /// Waiting for a child process to complete.
     Await(Pid),
+    /// Waiting for an I/O operation to complete.
+    Io(crate::io_backend::IoToken),
 }
 
 /// Process lifecycle status.

--- a/crates/hiko-vm/src/runtime.rs
+++ b/crates/hiko-vm/src/runtime.rs
@@ -112,6 +112,12 @@ impl Runtime {
                 RunResult::Receive => {
                     self.handle_receive(pid);
                 }
+                RunResult::Io(_req) => {
+                    // Single-threaded runtime: I/O not supported, fail
+                    let process = self.processes.get_mut(&pid).unwrap();
+                    process.status =
+                        ProcessStatus::Failed("async I/O requires ThreadedRuntime".into());
+                }
             }
         }
 

--- a/crates/hiko-vm/src/threaded.rs
+++ b/crates/hiko-vm/src/threaded.rs
@@ -6,23 +6,24 @@ use std::sync::{Arc, Mutex};
 
 use dashmap::DashMap;
 
+use crate::io_backend::{IoBackend, IoToken, MockIoBackend};
 use crate::process::{BlockReason, Pid, Process, ProcessStatus};
 use crate::runtime_ops::{
-    self, ChildState, check_child_state, create_child_vm, deliver_message,
-    deliver_result_to_parent, prepare_delivery,
+    ChildState, check_child_state, create_child_vm, deliver_message, deliver_result_to_parent,
+    prepare_delivery,
 };
 use crate::scheduler::{FifoScheduler, Scheduler};
-use crate::sendable::SendableValue;
+use crate::sendable::{SendableValue, deserialize};
 use crate::value::Value;
 use crate::vm::{RunResult, VM};
 use hiko_compile::chunk::CompiledProgram;
 
 /// Thread-safe process table using DashMap for fine-grained locking.
-/// Each entry is independently lockable — workers accessing different
-/// processes don't block each other.
 struct ProcessTable {
     processes: DashMap<Pid, Process>,
     waiters: Mutex<HashMap<Pid, Vec<Pid>>>,
+    /// Map from IoToken to the process waiting for that I/O.
+    io_waiters: Mutex<HashMap<IoToken, Pid>>,
 }
 
 impl ProcessTable {
@@ -30,6 +31,7 @@ impl ProcessTable {
         Self {
             processes: DashMap::new(),
             waiters: Mutex::new(HashMap::new()),
+            io_waiters: Mutex::new(HashMap::new()),
         }
     }
 
@@ -70,8 +72,10 @@ impl ProcessTable {
 /// Multi-threaded hiko runtime.
 pub struct ThreadedRuntime {
     next_pid: Arc<AtomicU64>,
+    next_io_token: Arc<AtomicU64>,
     table: Arc<ProcessTable>,
     scheduler: Arc<dyn Scheduler>,
+    io_backend: Arc<dyn IoBackend>,
     num_workers: usize,
 }
 
@@ -79,10 +83,17 @@ impl ThreadedRuntime {
     pub fn new(num_workers: usize) -> Self {
         Self {
             next_pid: Arc::new(AtomicU64::new(1)),
+            next_io_token: Arc::new(AtomicU64::new(1)),
             table: Arc::new(ProcessTable::new()),
             scheduler: Arc::new(FifoScheduler::new(1000)),
+            io_backend: Arc::new(MockIoBackend::new()),
             num_workers,
         }
+    }
+
+    pub fn with_io_backend(mut self, backend: Arc<dyn IoBackend>) -> Self {
+        self.io_backend = backend;
+        self
     }
 
     fn new_pid(&self) -> Pid {
@@ -105,19 +116,54 @@ impl ThreadedRuntime {
                 let table = Arc::clone(&self.table);
                 let scheduler = Arc::clone(&self.scheduler);
                 let next_pid = Arc::clone(&self.next_pid);
+                let next_io_token = Arc::clone(&self.next_io_token);
+                let io_backend = Arc::clone(&self.io_backend);
 
                 std::thread::spawn(move || {
-                    worker_loop(&table, &*scheduler, &next_pid);
+                    worker_loop(&table, &*scheduler, &next_pid, &next_io_token, &*io_backend);
                 })
             })
             .collect();
 
-        // Monitor: wait for all processes to complete, then signal shutdown
+        // Monitor: poll I/O completions and check for termination
         loop {
             std::thread::sleep(std::time::Duration::from_millis(1));
+
+            // Poll I/O backend for completed operations
+            let completions = self.io_backend.poll();
+            for (token, result) in completions {
+                let io_waiters = self.table.io_waiters.lock().unwrap();
+                if let Some(&pid) = io_waiters.get(&token) {
+                    drop(io_waiters);
+                    // Deliver I/O result to the blocked process
+                    if let Some(mut process) = self.table.processes.get_mut(&pid) {
+                        let val = match result {
+                            crate::io_backend::IoResult::Ok(sv) => {
+                                deliver_message(&mut process.vm, sv);
+                                true
+                            }
+                            crate::io_backend::IoResult::Err(msg) => {
+                                process.status = ProcessStatus::Failed(format!("I/O error: {msg}"));
+                                false
+                            }
+                        };
+                        if val {
+                            process.status = ProcessStatus::Runnable;
+                            drop(process);
+                            self.scheduler.enqueue(pid);
+                        }
+                    }
+                    self.table.io_waiters.lock().unwrap().remove(&token);
+                }
+            }
+
             if self.table.is_all_done_or_blocked() {
-                self.scheduler.shutdown();
-                break;
+                // Check if any are blocked on I/O — if so, keep polling
+                let has_io_waiters = !self.table.io_waiters.lock().unwrap().is_empty();
+                if !has_io_waiters {
+                    self.scheduler.shutdown();
+                    break;
+                }
             }
         }
 
@@ -129,7 +175,13 @@ impl ThreadedRuntime {
     }
 }
 
-fn worker_loop(table: &ProcessTable, scheduler: &dyn Scheduler, next_pid: &AtomicU64) {
+fn worker_loop(
+    table: &ProcessTable,
+    scheduler: &dyn Scheduler,
+    next_pid: &AtomicU64,
+    next_io_token: &AtomicU64,
+    io_backend: &dyn IoBackend,
+) {
     loop {
         let pid = match scheduler.dequeue() {
             Some(pid) => pid,
@@ -186,6 +238,14 @@ fn worker_loop(table: &ProcessTable, scheduler: &dyn Scheduler, next_pid: &Atomi
             }
             RunResult::Receive => {
                 handle_receive(table, scheduler, process);
+            }
+            RunResult::Io(request) => {
+                // Register I/O with backend, block process
+                let token = IoToken(next_io_token.fetch_add(1, Ordering::Relaxed));
+                process.status = ProcessStatus::Blocked(BlockReason::Io(token));
+                table.return_process(process);
+                table.io_waiters.lock().unwrap().insert(token, pid);
+                io_backend.register(token, request);
             }
         }
     }

--- a/crates/hiko-vm/src/threaded.rs
+++ b/crates/hiko-vm/src/threaded.rs
@@ -13,7 +13,7 @@ use crate::runtime_ops::{
     prepare_delivery,
 };
 use crate::scheduler::{FifoScheduler, Scheduler};
-use crate::sendable::{SendableValue, deserialize};
+use crate::sendable::SendableValue;
 use crate::value::Value;
 use crate::vm::{RunResult, VM};
 use hiko_compile::chunk::CompiledProgram;

--- a/crates/hiko-vm/src/vm.rs
+++ b/crates/hiko-vm/src/vm.rs
@@ -38,6 +38,8 @@ pub enum RunResult {
     },
     /// Process requested to receive a message.
     Receive,
+    /// Process requested an async I/O operation.
+    Io(crate::io_backend::IoRequest),
 }
 
 #[derive(Debug)]
@@ -113,6 +115,7 @@ pub enum RuntimeRequest {
         value: crate::sendable::SendableValue,
     },
     Receive,
+    Io(crate::io_backend::IoRequest),
 }
 
 pub(crate) fn values_equal(a: Value, b: Value, heap: &Heap) -> bool {
@@ -446,6 +449,7 @@ impl VM {
                 RuntimeRequest::Await(pid) => RunResult::Await(pid),
                 RuntimeRequest::Send { target_pid, value } => RunResult::Send { target_pid, value },
                 RuntimeRequest::Receive => RunResult::Receive,
+                RuntimeRequest::Io(req) => RunResult::Io(req),
             };
         }
 


### PR DESCRIPTION
## Summary

- `IoBackend` trait: `register(token, request)` + `poll() -> completions`
- `MockIoBackend`: completes all requests immediately (deterministic testing)
- `IoToken`, `IoRequest` (Sleep, Custom), `IoResult` (Ok, Err)
- Wired into `ThreadedRuntime`: workers signal I/O, monitor polls and wakes
- `BlockReason::Io(IoToken)` for process suspension

This is the infrastructure for async I/O without function coloring. The next step is adding a `perform_io` builtin that hiko code calls to trigger I/O suspension, and a real I/O backend (polling/epoll/io_uring).

## Test plan

- [x] Mock backend: sleep completes immediately
- [x] Mock backend: custom echoes payload
- [x] Mock backend: poll drains
- [x] All 271 tests pass

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)